### PR TITLE
Minor fixes

### DIFF
--- a/bin/dragon
+++ b/bin/dragon
@@ -56,7 +56,6 @@ fi
 
 while ! [[ -z $1 ]]; do
     case $1 in
-
         # --------
         # Set Variables
         # --------
@@ -95,7 +94,8 @@ while ! [[ -z $1 ]]; do
                                 set -xv
                                 export DGEN_DEBUG=1
                                 ;;
-        c | clean )             clean=1
+        c | clean )             gen=1
+                                clean=1
                                 ;;
         vn )                    NINJA_ARGS="-v"
                                 ;;
@@ -152,37 +152,59 @@ while ! [[ -z $1 ]]; do
     shift
 done
 
+
+# --------
+# Generate project info
+# --------
+if [[ $gen -eq 1 ]]; then
+    # Invoke the generator
+    # shellcheck disable=SC2154
+    rm -rf "$DRAGON_DATA_DIR/ninja/build.ninja" 2>/dev/null
+    mkdir -p "$DRAGON_DATA_DIR/"{ninja,modules}
+
+    generate
+
+    if [[ $DRAGONGEN_FAILURE -eq 1 ]]; then
+        cleanbuildfail
+    fi
+fi
+
+
+get_subprojs()
+{
+    set -f
+    # If there's more than one project in the root directory we need to iterate by name.
+    # Relying on generator to obtain project info
+    # shellcheck disable=SC2207
+    subsb=($(python3 -c "print('${project_dirs}' if ('${project_dirs}'.count('.')<2) else '${project_names}')"))
+    set +f
+    for i in "${subsb[@]}"; do
+        echo "$i"
+    done
+}
+
+
+# --------
+# Clean project(s)
+# --------
+if [[ $clean -eq 1 ]]; then
+    # clean subproj build dir(s)
+    get_subprojs | while read -r i; do
+        clean_dir $i
+    done
+    # ensure clean primary build dir
+    clean_dir .
+fi
+
+
 # --------
 # Build, then package (if needed)
 # --------
 if [[ $build -eq 1 ]]; then
-    # shellcheck disable=SC2154
-    # Invoke the generator
-    if [[ $gen -eq 1 ]]; then
-        rm -rf "$DRAGON_DATA_DIR/ninja/build.ninja" 2>/dev/null
-        mkdir -p "$DRAGON_DATA_DIR/"{ninja,modules}
-
-        generate
-
-        if [[ $DRAGONGEN_FAILURE -eq 1 ]]; then
-            cleanbuildfail
-        fi
-    fi
-
-    set -f
-    # If there's more than one project in the root directory we need to iterate by name.
-    # shellcheck disable=SC2207
-    subsb=($(python3 -c "print('${project_dirs}' if ('${project_dirs}'.count('.')<2) else '${project_names}')"))
-    set +f
-
     mkdir -p "$DRAGON_DATA_DIR"
     cp DragonMake "$DRAGON_DATA_DIR/DragonMake" 2> /dev/null
 
-    if [[ $clean -eq 1 && ! -f $DRAGON_DATA_DIR/.clean ]]; then
-        clean_dir $PWD
-    fi
-
-    for i in "${subsb[@]}"; do
+    get_subprojs | while read -r i; do
         # Copy the DragonMake into the subproject's build directory
         # Primarily for bundle filter gen, right now.
         if [[ -d $i ]]; then
@@ -202,17 +224,6 @@ if [[ $build -eq 1 ]]; then
 
     if [[ $norm -eq 0 ]]; then
         find . -name '*.ninja' -type f -delete
-    fi
-else
-    if [[ $gen -eq 1 ]]; then
-        rm -rf "$DRAGON_DATA_DIR/ninja/build.ninja" 2>/dev/null
-        mkdir -p "$DRAGON_DATA_DIR/"{ninja,modules}
-
-        generate
-
-        if [[ $DRAGONGEN_FAILURE -eq 1 ]]; then
-            cleanbuildfail
-        fi
     fi
 fi
 
@@ -236,6 +247,7 @@ if [[ $install -eq 1 && $DRAGON_DPKG -eq 1 ]]; then
     python3 -m dragon.device run ${INSTALL_CMD} || drexit
 fi
 
+
 # --------
 # On-device debugging
 # --------
@@ -245,6 +257,7 @@ if [[ $debug -eq 1 ]]; then
     ssh -p $DRBPORT root@$DRBIP "command -v lldb || apt install lldb" || drexit
     ssh -p $DRBPORT root@$DRBIP "lldb -n $debugproc || killall lldb" || drexit
 fi
+
 
 rm -rf "$DRAGON_DATA_DIR/packages" > /dev/null
 set +xv

--- a/bin/dragon
+++ b/bin/dragon
@@ -104,7 +104,6 @@ while ! [[ -z $1 ]]; do
                                 ;;
         vg )                    export DGEN_DEBUG=1
                                 ;;
-
         lo | objcs )            shift
                                 python3 -m dragon.lo $*
                                 drexit

--- a/bin/dragon
+++ b/bin/dragon
@@ -177,9 +177,12 @@ get_subprojs()
     # Relying on generator to obtain project info
     # shellcheck disable=SC2207
     subsb=($(python3 -c "print('${project_dirs}' if ('${project_dirs}'.count('.')<2) else '${project_names}')"))
+    proj_names=($(python3 -c "print('${project_names}')"))
     set +f
+    index=0
     for i in "${subsb[@]}"; do
-        echo "$i"
+        echo "$i ${proj_names[$index]}"
+        ((index++))
     done
 }
 
@@ -189,11 +192,11 @@ get_subprojs()
 # --------
 if [[ $clean -eq 1 ]]; then
     # clean subproj build dir(s)
-    get_subprojs | while read -r i; do
-        clean_dir $i
+    get_subprojs | while read -r i j; do
+        clean_dir $i $j
     done
     # ensure clean primary build dir
-    clean_dir .
+    clean_dir . $(basename $PWD)
 fi
 
 
@@ -204,14 +207,14 @@ if [[ $build -eq 1 ]]; then
     mkdir -p "$DRAGON_DATA_DIR"
     cp DragonMake "$DRAGON_DATA_DIR/DragonMake" 2> /dev/null
 
-    get_subprojs | while read -r i; do
+    get_subprojs | while read -r i j; do
         # Copy the DragonMake into the subproject's build directory
         # Primarily for bundle filter gen, right now.
         if [[ -d $i ]]; then
             mkdir -p "$i/$DRAGON_DIR/"
             cp DragonMake "$i/$DRAGON_DIR/DragonMake" 2> /dev/null
         fi
-        build $i
+        build $i $j
     done
 
     find . -name '.clean' -type f -delete

--- a/bin/dragon
+++ b/bin/dragon
@@ -178,6 +178,10 @@ if [[ $build -eq 1 ]]; then
     mkdir -p "$DRAGON_DATA_DIR"
     cp DragonMake "$DRAGON_DATA_DIR/DragonMake" 2> /dev/null
 
+    if [[ $clean -eq 1 && ! -f $DRAGON_DATA_DIR/.clean ]]; then
+        clean_dir $PWD
+    fi
+
     for i in "${subsb[@]}"; do
         # Copy the DragonMake into the subproject's build directory
         # Primarily for bundle filter gen, right now.

--- a/bin/dragon
+++ b/bin/dragon
@@ -84,8 +84,7 @@ while ! [[ -z $1 ]]; do
                                 ;;
         sim | simulator )       export simtarg=1
                                 ;;
-        i | install )           gen=1
-                                install=1
+        i | install )           install=1
                                 ;;
         debug )                 debug=1
                                 shift

--- a/src/dragon/shscripts/building
+++ b/src/dragon/shscripts/building
@@ -1,19 +1,34 @@
 #!/usr/bin/env bash
 
+get_name()
+{
+    if [[ $1 == "." ]]; then
+        i=$(basename $PWD)
+    else
+        i=$1
+    fi
+    echo "$i"
+}
+
 clean_dir()
 {
-    prefix_print "Cleaning $1"
-    if [[ -z $DRAGON_DIR ]];  then
-      drexit_reason "nil DRAGON_DIR"
+    DNAME=$(get_name $1)
+    pushd $DNAME &> /dev/null
+    if ! [[ -f $DRAGON_DIR/.clean ]]; then
+        prefix_print "Cleaning $DNAME"
+        if [[ -z $DRAGON_DIR ]];  then
+        drexit_reason "nil DRAGON_DIR"
+        fi
+        if [[ -f $DRAGON_DIR/DragonMake ]]; then
+            cp $DRAGON_DIR/DragonMake .DragonMake
+        fi
+        rm -rf $DRAGON_DIR/*
+        if [[ -f .DragonMake ]]; then
+            mv .DragonMake $DRAGON_DIR/DragonMake
+        fi
+        touch $DRAGON_DIR/.clean
     fi
-    if [[ -f $DRAGON_DIR/DragonMake ]]; then
-        cp $DRAGON_DIR/DragonMake .DragonMake
-    fi
-    rm -rf $DRAGON_DIR/*
-    if [[ -f .DragonMake ]]; then
-        mv .DragonMake $DRAGON_DIR/DragonMake
-    fi
-    touch $DRAGON_DIR/.clean
+    popd &> /dev/null
 }
 
 validate_objcs()
@@ -35,19 +50,10 @@ build()
 
     python3 -m dragongen.cliutils needsobjcs && validate_objcs
 
-    if [[ $1 == "." ]]; then
-        DNAME=${TWEAK_NAME}
-    else
-        DNAME=$1
-    fi
-
-    if [[ $clean -eq 1 && ! -f $DRAGON_DIR/.clean ]]; then
-        clean_dir $DNAME
-    fi
-
     mkdir -p $DRAGON_DIR/_/.dragonbuilding $DRAGON_DIR/modules
 
-    prefix_print "Building ${DNAME}"
+    DNAME=$(get_name $1)
+    prefix_print "Building $DNAME"
 
     if ! [[ -e build.ninja ]]; then
         mv "${i}.ninja" build.ninja

--- a/src/dragon/shscripts/building
+++ b/src/dragon/shscripts/building
@@ -1,21 +1,13 @@
 #!/usr/bin/env bash
 
-get_name()
-{
-    if [[ $1 == "." ]]; then
-        i=$(basename $PWD)
-    else
-        i=$1
-    fi
-    echo "$i"
-}
 
 clean_dir()
 {
-    DNAME=$(get_name $1)
+    DNAME=$1
+    PROJ=$2
     pushd $DNAME &> /dev/null
     if [[ -d $DRAGON_DIR && ! -f $DRAGON_DIR/.clean ]]; then
-        prefix_print "Cleaning $DNAME"
+        prefix_print "Cleaning $PROJ"
         if [[ -z $DRAGON_DIR ]];  then
         drexit_reason "nil DRAGON_DIR"
         fi
@@ -52,8 +44,9 @@ build()
 
     mkdir -p $DRAGON_DIR/_/.dragonbuilding $DRAGON_DIR/modules
 
-    DNAME=$(get_name $1)
-    prefix_print "Building $DNAME"
+    DNAME=$1
+    PROJ=$2
+    prefix_print "Building $PROJ"
 
     if ! [[ -e build.ninja ]]; then
         mv "${i}.ninja" build.ninja
@@ -79,7 +72,7 @@ build()
 
     # mv build.ninja $DRAGON_DIR/ninja # Was this renamed "ninja" for use elsewhere?
     mv build.ninja $DRAGON_DIR/build.ninja
-    if [[ $1 == "." ]]; then
+    if [[ $DNAME == "." ]]; then
         true
     else
         cp -R $DRAGON_DIR/_ "$DRAGON_DATA_DIR" 2>/dev/null

--- a/src/dragon/shscripts/building
+++ b/src/dragon/shscripts/building
@@ -14,7 +14,7 @@ clean_dir()
 {
     DNAME=$(get_name $1)
     pushd $DNAME &> /dev/null
-    if ! [[ -f $DRAGON_DIR/.clean ]]; then
+    if [[ -d $DRAGON_DIR && ! -f $DRAGON_DIR/.clean ]]; then
         prefix_print "Cleaning $DNAME"
         if [[ -z $DRAGON_DIR ]];  then
         drexit_reason "nil DRAGON_DIR"

--- a/src/dragon/shscripts/prerun_checks
+++ b/src/dragon/shscripts/prerun_checks
@@ -105,10 +105,7 @@ elif [[ ${PLATFORM,,} == linux ]]; then
 				prefix_print "Additional dependencies may also be required depending on what your distro provides."
 				;;
 		esac
-
-		curl -LO https://github.com/L1ghtmann/llvm-project/releases/download/test-e99a150/iOSToolchain.tar.xz
-		tar -xvf iOSToolchain.tar.xz -C $DRAGON_ROOT_DIR/toolchain/
-		rm iOSToolchain.tar.xz
+		curl -sL https://github.com/L1ghtmann/llvm-project/releases/download/test-e99a150/iOSToolchain.tar.xz | tar -xJvf - -C $DRAGON_ROOT_DIR/toolchain/
 	elif ! [[ -x $DRAGON_ROOT_DIR/toolchain/linux/iphone/bin/ldid ]]; then
 		prefix_print "You appear to be missing ldid, but have the toolchain. Not sure how we got here honestly ..."
 		prefix_print "Please build or download ldid from https://github.com/ProcursusTeam/ldid and place it in $DRAGON_ROOT_DIR/toolchain/linux/iphone/bin/."

--- a/src/dragon/wizard.py
+++ b/src/dragon/wizard.py
@@ -23,13 +23,13 @@ def setup_wizard():
     for repo in ('lib', 'include', 'frameworks', 'sdks', 'src'):
         if os.path.isdir(repo) and not os.path.isdir(f'{repo}/.git'):
             shutil.rmtree(repo)
-            os.system(f'git clone --depth=1 --recursive https://github.com/DragonBuild/{repo}')
+            os.system(f'git clone --recursive https://github.com/DragonBuild/{repo}')
         elif os.path.isdir(repo) and os.path.isdir(f'{repo}/.git'):
             os.chdir(repo)
             os.system('git pull origin $(git rev-parse --abbrev-ref HEAD)')
             os.chdir(dragon_root_dir)
         else:
-            os.system(f'git clone --depth=1 --recursive https://github.com/DragonBuild/{repo}')
+            os.system(f'git clone --recursive https://github.com/DragonBuild/{repo}')
 
     log('Deploying internal configuration')
     try:

--- a/src/dragongen/util.py
+++ b/src/dragongen/util.py
@@ -87,6 +87,13 @@ def interpret_theos_makefile(file: object, root: object = True) -> dict:
     finally:
         file.close()
 
+    if root:
+        project['name'] = os.path.basename(os.getcwd())
+        if 'INSTALL_TARGET_PROCESS' in variables:
+            project['icmd'] = 'killall -9 ' + variables['INSTALL_TARGET_PROCESS']
+        else:
+            project['icmd'] = 'sbreload'
+
     if os.environ['DGEN_DEBUG']:
         print("\n\n", file=sys.stderr)
         print("module type:" + str(module_type), file=sys.stderr)


### PR DESCRIPTION
Changes:
- Don't run gen on install
- Run gen on clean
- Allow clean by itself
- Fix improper cleaning of root build dir
- Abstract out a couple of things to prevent code dup
- Don't create intermediate file when installing Linux toolchain
- Clone submodules with entire git history
- Re-add _INSTALL_PROCESSES logic from unused Makefile processor 
  - Mistakenly thought this was duplicate code in d7d6518