### PR TITLE
Updates for rootless v2

### DIFF
--- a/src/dragon/config/defaults.yml
+++ b/src/dragon/config/defaults.yml
@@ -57,5 +57,5 @@ InternalDefaults:
 # Applied on top of both of these.
 Rootless:
   rootless_prefix: '/var/jb'
-  rpathflags: '-rpath $rootless_prefix/Library/Frameworks -rpath $rootless_prefix/usr/lib'
+  rpathflags: '-rpath $rootless_prefix/Library/Frameworks -rpath $rootless_prefix/usr/lib -rpath @loader_path/.jbroot/Library/Frameworks -rpath @loader_path/.jbroot/usr/lib'
   internalldflags: '$internalcflags $typeldflags $frameworks $libs $libflags $lopts $libSearch $ldflags $rpathflags'

--- a/src/dragon/config/types.yml
+++ b/src/dragon/config/types.yml
@@ -25,7 +25,7 @@ Types:
     variables:
       install_location: '/Library/MobileSubstrate/DynamicLibraries'
       build_target_file: '$dragon_data_dir/$stagedir$location/$name.dylib'
-      lopts: '-dynamiclib -ggdb -framework CydiaSubstrate'
+      lopts: '-dynamiclib -ggdb'
       ldflags: '-install_name @rpath/$name.dylib'
       frameworks:
         - UIKit


### PR DESCRIPTION
Prereqs:
- https://github.com/DragonBuild/lib/pull/3
- https://github.com/DragonBuild/include/pull/3

Useful but not strictly necessary:
- https://github.com/DragonBuild/frameworks/pull/3
- https://github.com/DragonBuild/src/pull/2
  - Note that this *is* necessary if 01e86763fc0f6d9ed349ef66ed442934a5331580 is merged

Changes:
- Removes explicit substrate link for tweaks as Logos handles this now (see above)
- Update supplied rpaths to support variable jbroot

Resolves #138 

**NOTE** not ready yet -- have to figure out dynamic libroot link